### PR TITLE
feat: Add Swagger UI setup using springdoc-openapi 2.8.6

### DIFF
--- a/Backend/build.gradle.kts
+++ b/Backend/build.gradle.kts
@@ -40,6 +40,8 @@ dependencies {
 	implementation("org.springframework.boot:spring-boot-starter-data-jpa")
 	implementation("org.mariadb.jdbc:mariadb-java-client:3.1.4") // 최신 드라이버
 
+	/* Swagger */
+	implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.6")
 
 	/* , Oauth, JWT, Mockito, Security, Webflux */
 

--- a/Backend/src/main/kotlin/com/gyugyufelt/gyugyufelt/controller/ColorAnaysisController.kt
+++ b/Backend/src/main/kotlin/com/gyugyufelt/gyugyufelt/controller/ColorAnaysisController.kt
@@ -2,6 +2,7 @@ package com.gyugyufelt.gyugyufelt.controller
 
 import com.gyugyufelt.gyugyufelt.dto.ColorAnalysisResponse
 import com.gyugyufelt.gyugyufelt.service.ColorAnalysisService
+import io.swagger.v3.oas.annotations.Operation
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestMapping
@@ -14,6 +15,7 @@ class ColorAnalysisController(
     private val colorAnalysisService: ColorAnalysisService
 ) {
 
+    @Operation(summary="테스트", description = "테스트 API입니다.")
     @PostMapping
     fun analyzeColors(
         @RequestParam k: Int,

--- a/Backend/src/main/kotlin/com/gyugyufelt/gyugyufelt/controller/ImageController.kt
+++ b/Backend/src/main/kotlin/com/gyugyufelt/gyugyufelt/controller/ImageController.kt
@@ -2,6 +2,7 @@ package com.gyugyufelt.gyugyufelt.controller;
 
 import com.gyugyufelt.gyugyufelt.dto.ColorResult
 import com.gyugyufelt.gyugyufelt.service.ImageService
+import io.swagger.v3.oas.annotations.Operation
 import org.springframework.http.MediaType
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -14,7 +15,9 @@ import org.springframework.web.multipart.MultipartFile;
 @RestController
 @RequestMapping("/api/image")
  class ImageController(private val imageService: ImageService ) {
-    @PostMapping("/upload", consumes = [MediaType.MULTIPART_FORM_DATA_VALUE])
+
+     @Operation(summary="이미지 내 대표 색상 추출", description = "이미지를 받아 5개의 대표 색상을 추출합니다.")
+     @PostMapping("/upload", consumes = [MediaType.MULTIPART_FORM_DATA_VALUE])
     fun uploadImage(@RequestPart image:MultipartFile) : ResponseEntity<List<ColorResult>>{
         val result = imageService.extractColors(image)
             return ResponseEntity.ok(result)

--- a/Backend/src/main/resources/application.yml
+++ b/Backend/src/main/resources/application.yml
@@ -7,7 +7,6 @@ spring:
     url: jdbc:mariadb://localhost:3306/woolfelt_db
     driver-class-name: org.mariadb.jdbc.Driver
 
-
   jpa:
     hibernate:
       ddl-auto: update
@@ -16,3 +15,10 @@ spring:
       hibernate:
         format_sql: true
 
+springdoc:
+  api-docs:
+    path: /api-docs
+  swagger-ui:
+    path: /swagger-ui.html
+    tagsSorter: alpha    # API 그룹 알파벳 순 정렬
+    operationSorter: method # HTTP Method 순 정렬 (G -> Po -> Pu ->  D)

--- a/readMe.md
+++ b/readMe.md
@@ -7,3 +7,19 @@
 
    ```bash
    docker compose -f docker-compose.dev.yml up -d
+    ```
+
+## Accessing Swagger UI
+
+1. Start the Server
+
+```bash
+./gradlew bootRun
+```
+
+2. Open your browser and go to:
+
+```bash
+http://localhost:8080/swagger-ui.html
+
+```


### PR DESCRIPTION
## Summary
Configured Swagger UI for API documentation using `springdoc-openapi` version 2.8.6.

## Details
- Added dependency: `springdoc-openapi-starter-webmvc-ui:2.8.6`
- Customized API docs and Swagger UI paths in `application.yml`
  - API Docs: `/api-docs`
  - Swagger UI: `/swagger-ui.html`
- Set `tagsSorter` and `operationSorter` for cleaner UI organization
- Updated `README.md` with Swagger access instructions

## Test
- Verified Swagger UI loads at `http://localhost:8080/swagger-ui.html`
- Confirmed that existing API endpoints are documented properly